### PR TITLE
FIX/CircleCI-install-chrome-driver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ jobs:
     # Then run your tests!
     # CircleCI will report the results back to your VCS provider.
     steps:
-      - browser-tools/install-chrome
+      - run: sudo apt-get update
+      - browser-tools/install-chrome:
+          chrome-version: "114.0.5735.90"
       - browser-tools/install-chromedriver
       - checkout
       - python/install-packages:
@@ -55,7 +57,9 @@ jobs:
     docker:
       - image: cimg/node:17.4-browsers
     steps:
-      - browser-tools/install-chrome
+      - run: sudo apt-get update
+      - browser-tools/install-chrome:
+          chrome-version: "114.0.5735.90"
       - browser-tools/install-chromedriver
       - run:
           name: Check install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
   # so you dont have to copy and paste it everywhere.
   # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
   python: circleci/python@2.1.1
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.3
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
   # so you dont have to copy and paste it everywhere.
   # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
   python: circleci/python@2.1.1
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.3
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
@@ -30,9 +30,7 @@ jobs:
     # Then run your tests!
     # CircleCI will report the results back to your VCS provider.
     steps:
-      - run: sudo apt-get update
-      - browser-tools/install-chrome:
-          chrome-version: "114.0.5735.90"
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - checkout
       - python/install-packages:
@@ -57,9 +55,7 @@ jobs:
     docker:
       - image: cimg/node:17.4-browsers
     steps:
-      - run: sudo apt-get update
-      - browser-tools/install-chrome:
-          chrome-version: "114.0.5735.90"
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:
           name: Check install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
   # so you dont have to copy and paste it everywhere.
   # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
   python: circleci/python@2.1.1
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.1
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
@@ -30,7 +30,9 @@ jobs:
     # Then run your tests!
     # CircleCI will report the results back to your VCS provider.
     steps:
-      - browser-tools/install-chrome
+      - run: sudo apt-get update
+      - browser-tools/install-chrome:
+          chrome-version: "114.0.5735.90"
       - browser-tools/install-chromedriver
       - checkout
       - python/install-packages:
@@ -55,7 +57,9 @@ jobs:
     docker:
       - image: cimg/node:17.4-browsers
     steps:
-      - browser-tools/install-chrome
+      - run: sudo apt-get update
+      - browser-tools/install-chrome:
+          chrome-version: "114.0.5735.90"
       - browser-tools/install-chromedriver
       - run:
           name: Check install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
   # so you dont have to copy and paste it everywhere.
   # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
   python: circleci/python@2.1.1
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.1
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs

--- a/Tests/requirements.txt
+++ b/Tests/requirements.txt
@@ -64,7 +64,7 @@ pytz==2023.3
 pyzmq==25.0.2
 requests==2.31.0
 rsa==4.9
-selenium==4.8.3
+selenium==4.10
 six==1.16.0
 sniffio==1.3.0
 sortedcontainers==2.4.0


### PR DESCRIPTION
Install chrome-driver step was failing due to new endpoints for chrome-driver.

~~New orb was released and this config files reference the new orb.~~

Reverted to using workaround since selenium (4.10) has a `webdrivers` component that has not been updated for Chrome >= 115.

